### PR TITLE
Cleanup the data loading pipeline

### DIFF
--- a/Load.ipynb
+++ b/Load.ipynb
@@ -59,8 +59,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 22.8 s, sys: 6.36 s, total: 29.2 s\n",
-      "Wall time: 26.6 s\n"
+      "CPU times: user 22 s, sys: 3.45 s, total: 25.4 s\n",
+      "Wall time: 22.4 s\n"
      ]
     }
    ],
@@ -120,17 +120,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 31 s, sys: 41.3 s, total: 1min 12s\n",
-      "Wall time: 1min 19s\n"
+      "CPU times: user 21.9 s, sys: 7.4 s, total: 29.3 s\n",
+      "Wall time: 21.9 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "raw_data = pd.merge(raw_data, pointing, left_on='cube_name', right_on='Image')\n",
-    "raw_data.rename(columns = {'RA':'im_ra'}, inplace = True) # Rename the columns\n",
-    "raw_data.rename(columns = {'DEC':'im_dec'}, inplace = True)\n",
-    "raw_data.drop(columns=['cube_name'], axis=1, inplace=True) # Get rid of the \"cube_name\" column as we now have \"Image\""
+    "raw_data = (pd.merge(raw_data, pointing, left_on='cube_name', right_on='Image')\n",
+    "                .rename(columns = {'RA':'im_ra', 'DEC':'im_dec'}) # Rename the columns\n",
+    "                .drop(columns=['cube_name'], axis=1) # Get rid of the \"cube_name\" column as we now have \"Image\"\n",
+    "           ) "
    ]
   },
   {
@@ -149,8 +149,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 707 ms, sys: 776 ms, total: 1.48 s\n",
-      "Wall time: 1.51 s\n"
+      "CPU times: user 1.49 s, sys: 105 ms, total: 1.59 s\n",
+      "Wall time: 402 ms\n"
      ]
     }
    ],
@@ -170,8 +170,18 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 10.8 s, sys: 3.15 s, total: 14 s\n",
+      "Wall time: 11.4 s\n"
+     ]
+    }
+   ],
    "source": [
+    "%%time\n",
     "gains = pd.read_table('all_gains.txt', ',')\n",
     "raw_data = pd.merge(raw_data, gains, left_on='Image', right_on='Image')"
    ]
@@ -187,9 +197,19 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 41.6 s, sys: 6.91 s, total: 48.5 s\n",
+      "Wall time: 33.7 s\n"
+     ]
+    }
+   ],
    "source": [
-    "raw_data.to_feather('mwats_raw_data.fth')"
+    "%%time\n",
+    "raw_data.to_parquet('mwats_raw_data.parq', engine='fastparquet')"
    ]
   }
  ],

--- a/Load.ipynb
+++ b/Load.ipynb
@@ -19,7 +19,6 @@
    "outputs": [],
    "source": [
     "import math\n",
-    "import dask.dataframe as dd\n",
     "import pandas as pd\n",
     "import numpy as np"
    ]
@@ -60,17 +59,31 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 25.9 s, sys: 18.9 s, total: 44.8 s\n",
-      "Wall time: 51.8 s\n"
+      "CPU times: user 22.8 s, sys: 6.36 s, total: 29.2 s\n",
+      "Wall time: 26.6 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
     "# Load the raw data file. \n",
-    "raw_data = dd.read_parquet('mwats_27_sept_full.parq').compute()\n",
-    "raw_data.drop(columns=['fit', 'blind_detection', 'polarisation', 'band', 'image_id', 'extname', 'cube_id', 'good_fit','fit_flags', 'flux_gain', 'pbcorr', 'peak_pixel'], axis=1, inplace=True)\n",
+    "raw_data = pd.read_parquet('data/mwats_27_sept_full.parq', engine='fastparquet')\n",
+    "raw_data.drop(columns=['fit', \n",
+    "                       'blind_detection', \n",
+    "                       'polarisation',\n",
+    "                       'band',\n",
+    "                       'image_id',\n",
+    "                       'extname',\n",
+    "                       'cube_id',\n",
+    "                       'good_fit',\n",
+    "                       'fit_flags',\n",
+    "                       'flux_gain',\n",
+    "                       'pbcorr', \n",
+    "                       'peak_pixel'], \n",
+    "              axis=1, inplace=True)\n",
+    "\n",
     "raw_data['raw_peak_flux'] = raw_data['raw_peak_flux']*(1.0/1000.0) # Conversion to Jy\n",
+    "\n",
     "raw_data['datetime'] = pd.to_datetime(raw_data.time)"
    ]
   },
@@ -182,9 +195,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pyviz",
    "language": "python",
-   "name": "python3"
+   "name": "pyviz"
   },
   "language_info": {
    "codemirror_mode": {
@@ -196,7 +209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Changes made to to the Load.ipynb notebook.

We're not using `dask` at the moment so I removed the `dask` step in the loading process, which makes the code cleaner, and might increase the speed (`fastparquet` is needed by `pandas`. If it's not already installed `pip install fastparquet` will do so).

I've changed the format of the reduced data file from feather to parquet. I used feather at first but I've found parquet to be faster to load/write and the resulting file has a smaller size. 
It also makes the file format consistent throughout the pipeline.

I've also cleaned up some of the code formatting and sped up the computation of `raw_data` by removing some of the intermediate steps.